### PR TITLE
Feat: Add Logout view to handle user sign-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -378,3 +378,5 @@ outputs/
 tmp/
 .DS_Store
 .vscode/
+
+Boyamarket/

--- a/Vue_2/frontend/src/router/index.js
+++ b/Vue_2/frontend/src/router/index.js
@@ -9,6 +9,7 @@ import UserCenter from '../views/UserCenter.vue';
 import Favorites from '../views/Favorites.vue';
 import Messages from '../views/Messages.vue';
 import ChatDetail from '../views/ChatDetail.vue';
+import Logout from '../views/Logout.vue';
 
 // 保留登录守卫逻辑
 const requireAuth = (to, from, next) => {
@@ -23,6 +24,7 @@ const requireAuth = (to, from, next) => {
 const routes = [
   { path: '/', name: 'Home', component: Home },
   { path: '/login', name: 'Login', component: Login },
+  { path: '/logout', name: 'Logout', component: Logout },
   { path: '/register', name: 'Register', component: Register },
   { path: '/item/:id', name: 'ItemDetail', component: ItemDetail },
   { path: '/publish', name: 'Publish', component: Publish, beforeEnter: requireAuth },

--- a/Vue_2/frontend/src/views/Logout.vue
+++ b/Vue_2/frontend/src/views/Logout.vue
@@ -1,0 +1,57 @@
+<template>
+    <div v-if="error" class="container mt-5">
+      <div class="alert alert-danger" role="alert">
+        登出失败: {{ error }}
+      </div>
+    </div>
+</template>
+
+<script>
+import api from '@/axios'
+
+export default {
+  name: 'Logout',
+  data() {
+    return {
+      error: null
+    }
+  },
+  mounted() {
+    this.performLogout()
+  },
+  methods: {
+    async performLogout() {
+        console.log('Logging out...')
+        try {
+            // 尝试通知后端登出（若后端未实现也不影响本地登出）
+            const res = await api.post('/auth/logout')
+        
+            if (res && res.ok === false) { // 后端返回失败响应，但是目前后端没有返回失败响应的情况
+                this.error = res.error?.message || '服务器拒绝登出请求' 
+            }
+        } catch (e) {
+            // 记录网络错误
+            console.error('logout error:', e)
+        } finally {
+        // 本地清理并跳转到登录页
+        localStorage.removeItem('access_token')
+        localStorage.removeItem('user_info')
+        console.log("Logout: localStorage cleared")
+        // 通知其它 tab，其他 tab 监听在 storage 事件中
+        try {
+            localStorage.setItem('logout', Date.now().toString())
+        } catch (e) {
+            console.error('Failed to set logout timestamp:', e)
+        }
+
+        // 通知当前 tab 登录状态已改变， 当前 tab 监听在 login-status-changed 事件中
+        window.dispatchEvent(new Event('login-status-changed'))
+
+        // 使用 replace 避免返回历史记录
+        this.$router.replace('/login').catch(()=>{})
+        console.log('Logout: finished, local cleared')
+      }
+    },
+  }
+}
+</script>


### PR DESCRIPTION
### 1. 新增前端 Logout 功能（Logout.vue）
**登出逻辑包括：**
	• 尝试调用后端 /auth/logout API（即使后端未实现也不影响前端登出流程）。
	• 清除本地登录状态：access_token，user_info
	• 向 localStorage 写入 logout 标记，用于跨 Tab 同步登出状态。
	• 手动触发 login-status-changed 事件，通知当前 Tab 的全局登录状态监听器。
	• 使用 router.replace('/login') 跳转到登录页面，避免用户返回历史记录。
**对失败情况进行提示：**
	• 如果后端返回失败信息，则显示错误。
	• 网络错误不会阻断本地登出逻辑。

### 2. 更新前端路由（router/index.js）
添加了 /logout 路由路径，将其指向新增的 Logout 组件。